### PR TITLE
Changing the navigation procedure.

### DIFF
--- a/src/Plugin.Maui.BottomSheet/Plugin.Maui.BottomSheet/Navigation/BottomSheetNavigationService.cs
+++ b/src/Plugin.Maui.BottomSheet/Plugin.Maui.BottomSheet/Navigation/BottomSheetNavigationService.cs
@@ -48,16 +48,16 @@ public sealed class BottomSheetNavigationService : IBottomSheetNavigationService
         {
             PrepareBottomSheetForNavigation(bottomSheet, viewModel, configure);
 
+            if (bottomSheet.BindingContext is IQueryAttributable queryAttributable)
+            {
+                ApplyAttributes(queryAttributable, parameters);
+            }
+
             if (bottomSheet.Handler is Handlers.BottomSheetHandler bottomSheetHandler)
             {
                 await bottomSheetHandler.OpenAsync().ConfigureAwait(true);
                 _bottomSheetStack.Add(bottomSheet);
                 _bottomSheetStack.Current.IsOpen = true;
-            }
-
-            if (bottomSheet.BindingContext is IQueryAttributable queryAttributable)
-            {
-                ApplyAttributes(queryAttributable, parameters);
             }
         });
     }


### PR DESCRIPTION
Moved ApplyAttributes before opening the BottomSheet. Previously, attributes were applied after opening the bottom sheet, which caused a visible lag. Now, ApplyAttributes is executed before calling OpenAsync(), ensuring a smoother experience.

fixes: https://github.com/lucacivale/Maui.BottomSheet/issues/89